### PR TITLE
Resolve module not found error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "main": "src/server.js",
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "scripts": {
     "start": "node src/server.js",
     "dev": "nodemon src/server.js",

--- a/render.yaml
+++ b/render.yaml
@@ -2,8 +2,9 @@ services:
   - type: web
     name: numina-server
     env: node
-    buildCommand: npm install
-    startCommand: npm start
+    region: oregon
+    buildCommand: npm ci && ls -la src/ && node --check src/server.js
+    startCommand: node src/server.js
     envVars:
       - key: NODE_ENV
         value: production


### PR DESCRIPTION
Update Render deployment configuration and specify Node.js engine to resolve 'Cannot find module' error.

The error was caused by the Render build process not reliably finding `src/server.js` and inconsistent start commands. The updated `buildCommand` now explicitly verifies the file's presence and syntax before deployment, and the `startCommand` directly executes the server, bypassing potential npm script resolution issues. Specifying the Node.js engine ensures compatibility.