### PR TITLE
Troubleshoot missing module in deployment

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,5 @@
+// Wrapper file for Render deployment
+// This file exists because Render is configured to run 'node server.js'
+// but our actual server is at src/server.js
+
+import('./src/server.js');

--- a/src/config/database.js
+++ b/src/config/database.js
@@ -15,7 +15,6 @@ const connectDB = async () => {
       socketTimeoutMS: 45000,    // Socket timeout
       family: 4,                 // Use IPv4, avoid slow IPv6 lookups
       bufferCommands: false,     // Disable mongoose buffering for better performance
-      bufferMaxEntries: 0,       // Disable mongoose buffering queue
       heartbeatFrequencyMS: 10000, // Heartbeat every 10 seconds
       retryReads: true,          // Enable read retries
       retryWrites: true,         // Enable write retries

--- a/src/server.js
+++ b/src/server.js
@@ -92,7 +92,6 @@ mongoose.connect(process.env.MONGO_URI, {
   socketTimeoutMS: 45000,
   family: 4,
   bufferCommands: false,     // Disable mongoose buffering
-  bufferMaxEntries: 0,       // Disable mongoose buffering
 })
 .then(() => console.log("✓MongoDB connected with optimized pool settings"))
 .catch((err) => {


### PR DESCRIPTION
Add a root `server.js` wrapper and remove deprecated `bufferMaxEntries` from Mongoose connection options.

The root `server.js` wrapper addresses a deployment issue where Render was attempting to run `node server.js` from the project root, while the main server file is located at `src/server.js`. This provides a workaround without requiring changes to Render's start command settings. The `bufferMaxEntries` option was removed as it is deprecated in Mongoose 6.x and caused a `MongoParseError`.