### PR TITLE
Implement emotion logging endpoints

### DIFF
--- a/src/models/User.js
+++ b/src/models/User.js
@@ -23,10 +23,12 @@ const userSchema = new mongoose.Schema({
   },
   emotionalLog: [
     {
-      emotion: { type: String, required: true, trim: true },
-      intensity: { type: Number, min: 1, max: 10, required: false },
-      context: { type: String, required: false, trim: true },
+      emotion: { type: String, required: true, trim: true }, // stored mood
+      intensity: { type: Number, min: 1, max: 10, required: true },
+      context: { type: String, trim: true }, // stored notes
       timestamp: { type: Date, default: Date.now },
+      timeZone: { type: String, trim: true },
+      deviceInfo: { type: String, trim: true },
     },
   ],
   createdAt: { type: Date, default: Date.now },
@@ -36,6 +38,7 @@ const userSchema = new mongoose.Schema({
 // Indexes for better performance
 // Note: email index is automatically created by unique: true
 userSchema.index({ createdAt: -1 });
+userSchema.index({ _id: 1, 'emotionalLog.timestamp': -1 });
 
 // Pre-save hook to hash password
 userSchema.pre("save", async function (next) {

--- a/src/routes/emotionHistory.js
+++ b/src/routes/emotionHistory.js
@@ -45,10 +45,12 @@ router.get("/", protect, async (req, res) => {
     // Format emotions for frontend
     const formattedEmotions = paginatedEmotions.map(emotion => ({
       id: emotion._id,
-      emotion: emotion.emotion,
+      mood: emotion.emotion,
       intensity: emotion.intensity,
-      context: emotion.context,
+      notes: emotion.context,
       timestamp: emotion.timestamp,
+      timeZone: emotion.timeZone,
+      deviceInfo: emotion.deviceInfo,
       date: emotion.timestamp.toISOString().split('T')[0], // YYYY-MM-DD format
       time: emotion.timestamp.toISOString().split('T')[1].substring(0, 5) // HH:MM format
     }));

--- a/src/routes/emotions.js
+++ b/src/routes/emotions.js
@@ -11,18 +11,18 @@ router.post("/", protect, async (req, res) => {
   try {
     const userId = req.user.id;
     
-    // Map frontend fields to backend expected names
-    const { mood: emotion, intensity, notes: context, date } = req.body;
+    // Extract fields from frontend
+    const { mood, intensity, notes, timestamp, timeZone, deviceInfo } = req.body;
 
     // Validate required fields
-    if (!emotion || typeof emotion !== 'string' || emotion.trim().length === 0) {
+    if (!mood || typeof mood !== 'string' || mood.trim().length === 0) {
       return res.status(400).json({
         message: "Emotion is required and must be a non-empty string"
       });
     }
 
-    // Validate intensity if provided
-    if (intensity !== undefined && (typeof intensity !== 'number' || intensity < 1 || intensity > 10)) {
+    // Validate intensity
+    if (typeof intensity !== 'number' || intensity < 1 || intensity > 10) {
       return res.status(400).json({
         message: "Intensity must be a number between 1 and 10"
       });
@@ -38,10 +38,12 @@ router.post("/", protect, async (req, res) => {
 
     // Create the emotional entry
     const emotionalEntry = {
-      emotion: emotion.trim(),
-      intensity: intensity || undefined,
-      context: context?.trim() || undefined,
-      timestamp: new Date()
+      emotion: mood.trim(),
+      intensity,
+      context: notes?.trim() || undefined,
+      timestamp: timestamp ? new Date(timestamp) : new Date(),
+      timeZone: timeZone || undefined,
+      deviceInfo: deviceInfo || undefined
     };
 
     // Add to user's emotional log
@@ -61,10 +63,12 @@ router.post("/", protect, async (req, res) => {
       message: "Emotional entry submitted successfully",
       entry: {
         id: user.emotionalLog[user.emotionalLog.length - 1]._id,
-        emotion: emotionalEntry.emotion,
+        mood: emotionalEntry.emotion,
         intensity: emotionalEntry.intensity,
-        context: emotionalEntry.context,
-        timestamp: emotionalEntry.timestamp
+        notes: emotionalEntry.context,
+        timestamp: emotionalEntry.timestamp,
+        timeZone: emotionalEntry.timeZone,
+        deviceInfo: emotionalEntry.deviceInfo
       }
     });
 

--- a/src/server.js
+++ b/src/server.js
@@ -77,7 +77,9 @@ const initializeServer = async () => {
   app.use(requestLogger);
 
   // --- Database Connection ---
-  await connectDB();
+  if (process.env.NODE_ENV !== 'test') {
+    await connectDB();
+  }
 
   // --- Global HTTPS Agent for Performance ---
   const globalHttpsAgent = new https.Agent({
@@ -156,7 +158,9 @@ const initializeServer = async () => {
 };
 
 // Start the server
-if (process.env.NODE_ENV !== 'test') {
+if (process.env.NODE_ENV === 'test') {
+  await initializeServer();
+} else {
   initializeServer().catch(err => {
     console.error('Failed to initialize server:', err);
     process.exit(1);

--- a/tests/routes/emotions.test.js
+++ b/tests/routes/emotions.test.js
@@ -1,0 +1,73 @@
+import request from 'supertest';
+import app from '../../src/server.js';
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import User from '../../src/models/User.js';
+
+let mongoServer;
+let authToken;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create({ binary: { version: '7.0.3' } });
+  const mongoUri = mongoServer.getUri();
+  await mongoose.connect(mongoUri);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongoServer) await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await User.deleteMany({});
+  const signup = await request(app)
+    .post('/signup')
+    .send({ email: 'emo@test.com', password: 'password123' });
+  authToken = signup.body.token;
+});
+
+describe('Emotion Routes', () => {
+  test('POST /emotions stores emotion entry', async () => {
+    const payload = {
+      mood: 'happy',
+      intensity: 8,
+      notes: 'feeling great',
+      timestamp: new Date().toISOString(),
+      timeZone: 'UTC',
+      deviceInfo: 'jest'
+    };
+
+    const res = await request(app)
+      .post('/emotions')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body.entry.mood).toBe('happy');
+    expect(res.body.entry.timeZone).toBe('UTC');
+  });
+
+  test('GET /emotion-history returns logged emotion', async () => {
+    await request(app)
+      .post('/emotions')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        mood: 'sad',
+        intensity: 5,
+        notes: 'test',
+        timestamp: new Date().toISOString(),
+        timeZone: 'UTC',
+        deviceInfo: 'jest'
+      });
+
+    const res = await request(app)
+      .get('/emotion-history?limit=10&page=1')
+      .set('Authorization', `Bearer ${authToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.emotions.length).toBeGreaterThan(0);
+    const entry = res.body.emotions[0];
+    expect(entry.mood).toBeDefined();
+    expect(entry.timeZone).toBe('UTC');
+  });
+});


### PR DESCRIPTION
## Summary
- extend `User` model with timezone and device info fields
- store synced emotion logs using new schema
- expose POST `/emotions` with validation for mood entries
- return timezone and device info from GET `/emotion-history`
- initialize server during tests and skip DB connection
- add a small test covering emotion logging

## Testing
- `npm test` *(fails: MongooseServerSelectionError and timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68722d2d0efc83208d3b001b5429fda5